### PR TITLE
Too many args in exit and ft_builtins take t_cmd in params

### DIFF
--- a/include/fterr.h
+++ b/include/fterr.h
@@ -36,7 +36,8 @@
 # define FTERR_UNSET "Error: Invalid option"
 # define FTERR_UNSET_VAL 2
 
-# define FTERR_EXIT "exit: %s: numeric argument required\n"
+# define FTERR_EXIT_NB "exit: %s: numeric argument required\n"
+# define FTERR_EXIT_ARG "exit\nError: too many arguments"
 
 # define FTERR_HDOC_D "Warning: Heredoc delimited by end-of-file (wanted '%s')"
 

--- a/src/builtins/ft_builtins.c
+++ b/src/builtins/ft_builtins.c
@@ -12,12 +12,12 @@
 
 #include "skibidi_shell.h"
 
-int	ft_builtins(t_shell *sh, t_list **env, t_builtins *builtins)
+int	ft_builtins(t_shell *sh, t_cmd *cmd, t_list **env, t_builtins *builtins)
 {
 	t_list	*args;
 	int		idx0;
 
-	args = ((t_cmd *)sh->cmd->content)->arg;
+	args = cmd->arg;
 	idx0 = get_tabindex(hash_key(((t_arg *)args->content)->name));
 	return (builtins[idx0].fn(sh, env));
 }

--- a/src/builtins/ft_exit.c
+++ b/src/builtins/ft_exit.c
@@ -23,12 +23,17 @@ int	ft_exit(t_shell *sh, t_list **env)
 	if (!((t_cmd *)sh->cmd->content)->arg->next)
 		exit(atoi(sh->last_err));
 	args = ((t_cmd *)sh->cmd->content)->arg->next;
+	if (args->next)
+	{
+		ft_putstr_fd(FTERR_EXIT_ARG"\n", STDOUT_FILENO);
+		return (1);
+	}
 	arg_name = ((t_arg *)args->content)->name;
 	while (arg_name[i])
 	{
 		if (!isdigit(arg_name[i++]))
 		{
-			ft_printfd(STDERR_FILENO, FTERR_EXIT, arg_name);
+			ft_printfd(STDERR_FILENO, FTERR_EXIT_NB, arg_name);
 			exit(255);
 		}
 	}


### PR DESCRIPTION
I add an eror handling in ft_exit when the cmd is called qith too many args.
I also modified the ft_builtins function that now take a new param, t_cmd as the current cmd when called